### PR TITLE
Add `iyperm` keyword to `inpoly2`, to skip sortperm when our points are sorted

### DIFF
--- a/src/inpoly2.jl
+++ b/src/inpoly2.jl
@@ -21,7 +21,7 @@ outside numerically.
 Expected effort of the algorithm is `(N+M)*log(M)`, where `M` is the number of points
 and `N` is the number of polygon edges.
 """
-function inpoly2(vert, node, edge=zeros(Int); atol::T=0.0, rtol::T=NaN, outformat=InOnBit) where T<:AbstractFloat
+function inpoly2(vert, node, edge=zeros(Int); atol::T=0.0, rtol::T=NaN, iyperm=nothing, outformat=InOnBit) where T<:AbstractFloat
 
     rtol = !isnan(rtol) ? rtol : iszero(atol) ? eps(T)^0.85 : zero(T)
     poly = PolygonMesh(node, edge)
@@ -42,7 +42,9 @@ function inpoly2(vert, node, edge=zeros(Int); atol::T=0.0, rtol::T=NaN, outforma
 
     dvert = vmax - vmin
     ix = dvert[1] < dvert[2] ? 1 : 2
-    iyperm = sortperm(points, 3 - ix)
+    if isnothing(iyperm)
+        iyperm = sortperm(points, 3 - ix)
+    end
 
     inpoly2!(points, iyperm, poly, ix, tol, stat)
 


### PR DESCRIPTION
Sometimes we know the `sortperm` order already, and this can save a lot of time. This PR adds an `iyperm` keyword so we can manually skip calculating `iyperm` if we already know what it is.